### PR TITLE
Resolve issue #9

### DIFF
--- a/youdao/main.py
+++ b/youdao/main.py
@@ -155,6 +155,9 @@ def parse_args():
 
 
 def main():
+    # resolve issue #9
+    reload(sys)
+    sys.setdefaultencoding('utf-8')
     args = parse_args()
     config.prepare()
 


### PR DESCRIPTION
If we want to support ">>" command,the error "UnicodeEncodeError: ‘ascii’ codec can’t encode异常错误".
The commit may resolve it.