### PR TITLE
Fix 'SqliteDatabase' object has no attribute 'drop_table' when db is …

### DIFF
--- a/youdao/config.py
+++ b/youdao/config.py
@@ -37,7 +37,8 @@ def update():
     if config.get('version', '0') < '0.2.0':
         # silent_remove(DB_DIR)
         from model import db, Word
-        db.drop_table(Word, fail_silently=True)
+        if os.path.exists(DB_DIR):
+            db.drop_table(Word, fail_silently=True)
         Word.create_table()
 
 


### PR DESCRIPTION
fix this error when install youdao on new device

File "/usr/local/lib/python2.7/dist-packages/youdao/config.py", line 40, in update
db.drop_table(Word, fail_silently=True)
AttributeError: 'SqliteDatabase' object has no attribute 'drop_table'
